### PR TITLE
Use pre-built container image to make installation faster and backups smaller.

### DIFF
--- a/.github/workflows/builder.yml
+++ b/.github/workflows/builder.yml
@@ -1,0 +1,116 @@
+---
+# yamllint disable rule:line-length rule:truthy
+name: Build add-on
+
+env:
+  BUILD_ARGS: "--test"
+  MONITORED_FILES: "apparmor.txt build.yaml config.yaml Dockerfile data rootfs"
+
+on:
+  pull_request:
+    branches: ["master"]
+  push:
+    branches: ["master"]
+
+jobs:
+  init:
+    runs-on: ubuntu-latest
+    name: Initialize builds
+    outputs:
+      changed_files: ${{ steps.changed_files.outputs.all }}
+      changed_addons: ${{ steps.changed_addons.outputs.addons }}
+      changed: ${{ steps.changed_addons.outputs.changed }}
+    steps:
+      - name: Check out the repository
+        uses: actions/checkout@v3
+
+      - name: Get changed files
+        id: changed_files
+        uses: jitterbit/get-changed-files@v1
+
+      - name: Get add-ons
+        id: addons
+        run: |
+          declare -a addons
+          for addon in $(find ./ -name config.yaml | cut -d "/" -f2 | sort -u); do
+            addons+=("$addon");
+          done
+          echo "::set-output name=addons::${addons[@]}"
+
+      - name: Get changed add-ons
+        id: changed_addons
+        run: |
+          declare -a changed_addons
+          for addon in ${{ steps.addons.outputs.addons }}; do
+            if [[ "${{ steps.changed_files.outputs.all }}" =~ $addon ]]; then
+              for file in ${{ env.MONITORED_FILES }}; do
+                  if [[ "${{ steps.changed_files.outputs.all }}" =~ $addon/$file ]]; then
+                    if [[ ! "${changed_addons[@]}" =~ $addon ]]; then
+                      changed_addons+=("\"${addon}\",");
+                    fi
+                  fi
+              done
+            fi
+          done
+
+          changed=$(echo ${changed_addons[@]} | rev | cut -c 2- | rev)
+          if [[ -n ${changed} ]]; then
+            echo "Changed add-ons: $changed";
+            echo "::set-output name=changed::true";
+            echo "::set-output name=addons::[$changed]";
+          else
+            echo "No add-on had any monitored files changed (${{ env.MONITORED_FILES }})";
+          fi
+
+  build:
+    needs: init
+    runs-on: ubuntu-latest
+    if: needs.init.outputs.changed == 'true'
+    name: Build ${{ matrix.arch }} ${{ matrix.addon }} add-on
+    strategy:
+      matrix:
+        addon: ${{ fromJson(needs.init.outputs.changed_addons) }}
+        arch: ["aarch64", "amd64", "armhf", "armv7", "i386"]
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v3
+
+      - name: Get information
+        id: info
+        uses: home-assistant/actions/helpers/info@master
+        with:
+          path: "./${{ matrix.addon }}"
+
+      - name: Check add-on
+        id: check
+        run: |
+          if [[ "${{ steps.info.outputs.architectures }}" =~ ${{ matrix.arch }} ]]; then
+             echo "::set-output name=build_arch::true";
+           else
+             echo "${{ matrix.arch }} is not a valid arch for ${{ matrix.addon }}, skipping build";
+          fi
+
+      - name: Set build arguments
+        if: steps.check.outputs.build_arch == 'true'
+        run: |
+          if [[ -z "${{ github.head_ref }}" ]] && [[ "${{ github.event_name }}" == "push" ]]; then
+              echo "BUILD_ARGS=--docker-hub-check" >> $GITHUB_ENV;
+          fi
+
+      - name: Login to DockerHub
+        if: env.BUILD_ARGS == '--docker-hub-check'
+        uses: docker/login-action@v2.0.0
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Build ${{ matrix.addon }} add-on
+        if: steps.check.outputs.build_arch == 'true'
+        uses: home-assistant/builder@2022.09.0
+        with:
+          args: |
+            ${{ env.BUILD_ARGS }} \
+            --${{ matrix.arch }} \
+            --target /data/${{ matrix.addon }} \
+            --addon

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,52 @@
+---
+# yamllint disable rule:truthy
+name: Lint
+
+env:
+  HADOLINT_VERSION: v1.17.2
+  SHELLCHECK_OPTS: -e SC1008 -s bash
+
+on:
+  pull_request:
+    branches: ["master"]
+  push:
+    branches: ["master"]
+
+jobs:
+  hadolint:
+    runs-on: ubuntu-latest
+    name: hadolint
+    steps:
+      - name: Check out the repository
+        uses: actions/checkout@v3
+
+      - name: Run linter
+        id: changed_files
+        run: |
+          shopt -s globstar
+          for dockerfile in **/Dockerfile; do
+            echo "Linting: $dockerfile"
+            docker run --rm -i \
+              -v $(pwd)/.hadolint.yaml:/.hadolint.yaml:ro \
+              hadolint/hadolint:${{ env.HADOLINT_VERSION }} < "$dockerfile"
+          done
+
+  yamllint:
+    runs-on: ubuntu-latest
+    name: YAMLLint
+    steps:
+      - name: Check out the repository
+        uses: actions/checkout@v3
+
+      - name: Run YAMLLint
+        uses: frenck/action-yamllint@v1.3
+
+  shellcheck:
+    runs-on: ubuntu-latest
+    name: ShellCheck
+    steps:
+      - name: Check out the repository
+        uses: actions/checkout@v3
+
+      - name: Run linter
+        uses: ludeeus/action-shellcheck@1.1.0

--- a/homebridge/CHANGELOG.md
+++ b/homebridge/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 
 
+## [0.1.5] - 2022-11-04
+
+- Use pre-built container image to make installation faster and backups smaller.
+
 ## [0.1.4] - 2022-11-04
 
 - Enable host_network otherwise accessories aren't discovered by Home Assistant.

--- a/homebridge/Dockerfile
+++ b/homebridge/Dockerfile
@@ -1,4 +1,4 @@
-FROM oznu/homebridge:ubuntu
+FROM oznu/homebridge:2022-10-14-ubuntu
 
 # Relocate homebridge working directory so it can be persisted
 RUN find /etc/s6-overlay/ -type f | xargs sed -i -E 's:([ "])/homebridge:\1$(cat /data/options.json | jq -r .homebridge_workdir):g'

--- a/homebridge/README.md
+++ b/homebridge/README.md
@@ -5,7 +5,7 @@ This is an [Homebridge](https://homebridge.io) add-on for [Home Assistant](https
 Note that Home Assistant supports HomeKit natively these days, both as a [controller](https://www.home-assistant.io/integrations/homekit_controller/) and as a [device](https://www.home-assistant.io/integrations/homekit/), so you probably don't need Homebridge if you just want to integrate with the HomeKit ecosystem. However, Homebrige has a lot of plugins, so it can still be useful to bridge some less-supported devices (e.g. [Nest](https://github.com/chrisjshull/homebridge-nest)) into Home Assistant.
 
 ## Installation
-Add the [add-on repository](https://github.com/davide125/hassio-addons) and install Homebridge from the add-on store. This may take a while: no prebuilt image is currently being provided so Home Assistant will build one for you at installation time. 
+Add the [add-on repository](https://github.com/davide125/hassio-addons) and install Homebridge from the add-on store.
 
 To configure Homebridge, forward the Homebridge UI port to the host in the add-on configuration to access it. The default credentials are the same as regular Homebridge (i.e. admin/admin); please change them on the first login.
 

--- a/homebridge/README.md
+++ b/homebridge/README.md
@@ -7,7 +7,7 @@ Note that Home Assistant supports HomeKit natively these days, both as a [contro
 ## Installation
 Add the [add-on repository](https://github.com/davide125/hassio-addons) and install Homebridge from the add-on store.
 
-To configure Homebridge, forward the Homebridge UI port to the host in the add-on configuration to access it. The default credentials are the same as regular Homebridge (i.e. admin/admin); please change them on the first login.
+To configure Homebridge click on OPEN WEB UI from the add-on page.
 
 ## Credits
 This add-on was inspired by [adsb-multi-portal-feeder](https://github.com/MaxWinterstein/homeassistant-addons/tree/main/adsb-multi-portal-feeder) to leverage a pre-existing Docker image and integrate it into an add-on ([Docker Homebridge](https://github.com/oznu/docker-homebridge) in this case). The add-on icon is derived from [Material Design Icons](https://materialdesignicons.com/icon/home-automation). These projects (and Homebridge itself) deserve all the credit here. This add-on is unrelated to the deprecated [addon-homebridge](https://github.com/hassio-addons/addon-homebridge).

--- a/homebridge/config.yaml
+++ b/homebridge/config.yaml
@@ -21,3 +21,4 @@ options:
   homebridge_workdir: "/config/homebridge"
 schema:
   homebridge_workdir: str
+image: tronikos/{arch}-addon-homebridge

--- a/homebridge/config.yaml
+++ b/homebridge/config.yaml
@@ -1,5 +1,5 @@
 name: Homebridge
-version: 0.1.4
+version: 0.1.5
 stage: experimental
 slug: homebridge
 description: Lightweight HomeKit API implementation with plugin support

--- a/homebridge/config.yaml
+++ b/homebridge/config.yaml
@@ -4,7 +4,6 @@ stage: experimental
 slug: homebridge
 description: Lightweight HomeKit API implementation with plugin support
 arch:
-  - armhf
   - armv7
   - aarch64
   - amd64


### PR DESCRIPTION
I was able to build images with following steps :

1. Create free docker hub account: tronikos
2. Create repositories at https://hub.docker.com/repositories:
- tronikos/armv7-addon-homebridge
- tronikos/amd64-addon-homebridge
- tronikos/aarch64-addon-homebridge
3. Generate new token at https://hub.docker.com/settings/security?generateToken=true
4. Create repository secrets DOCKERHUB_USERNAME and DOCKERHUB_TOKEN at https://github.com/tronikos/hassio-addons/settings/secrets/actions
5. Run: docker login -u tronikos
6. At the password prompt, enter the personal access token.
7. Publish new images with:
docker run \
  --rm \
  --privileged \
  -v ~/.docker:/root/.docker \
  homeassistant/amd64-builder \
  --all \
  -t homebridge \
  -r https://github.com/tronikos/hassio-addons \
  -b main

After merging feel free to update config.yml to point to your docker hub account and replace tronikos with your username in above steps.

For future releases you only need to run the last step. The added github actions should make this unnecessary for future pull requests. 