### PR TITLE
Exclude node_modules from backups to make them smaller

### DIFF
--- a/homebridge/config.yaml
+++ b/homebridge/config.yaml
@@ -17,4 +17,6 @@ host_network: true
 init: false
 map:
   - addon_config:rw
+backup_exclude:
+  - "config/node_modules"
 image: davide125/{arch}-addon-homebridge

--- a/homebridge/config.yaml
+++ b/homebridge/config.yaml
@@ -1,3 +1,4 @@
+---
 name: Homebridge
 version: 0.1.8
 stage: experimental

--- a/homebridge/config.yaml
+++ b/homebridge/config.yaml
@@ -18,5 +18,5 @@ init: false
 map:
   - addon_config:rw
 backup_exclude:
-  - "config/node_modules"
+  - "node_modules"
 image: davide125/{arch}-addon-homebridge


### PR DESCRIPTION
On my setup the node_modules is ~90MB. Compressed in the backup it's ~42MB. Reduce the backup size by excluding node_modules. I've verified that homebridge automatically downloads them at startup after I manually deleted them.